### PR TITLE
chore: pin GitHub Actions to specific versions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,7 +5,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 9.15.9
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.18.0"
           cache: "yarn"
@@ -22,7 +22,7 @@ jobs:
       - name: package
         run: yarn package
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 9.15.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.18.0"
           cache: "pnpm"


### PR DESCRIPTION
## Summary

This PR pins all GitHub Actions to specific SHA versions for improved security.

## Changes

Updated all workflow files to use SHA-pinned action versions:
- `actions/checkout@v5` → `actions/checkout@08c6903...v5.0.0`
- `pnpm/action-setup@v4` → `pnpm/action-setup@a7487c7...v4.1.0`
- `actions/setup-node@v4` → `actions/setup-node@49933ea...v4.4.0`
- `softprops/action-gh-release@v2` → `softprops/action-gh-release@72f2c25...v2.3.2`

## Why This Matters

Pinning actions to SHA hashes instead of tags provides:
- **Security**: Prevents malicious code injection if an action tag is moved
- **Reliability**: Ensures workflows always use the exact same action version
- **Compliance**: Follows GitHub security best practices

## Generated by

This update was generated using `pinact run` which automatically pins all GitHub Actions to their current SHA versions.