### PR TITLE
Use npm package script in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build extension
-        run: pnpm build
+      - name: Build and package extension
+        run: pnpm package
 
       - name: Get version from manifest.json
         id: version
@@ -43,20 +43,10 @@ jobs:
 
       - name: Create release package
         run: |
-          # Create a clean directory for packaging
-          mkdir -p release-package
+          # Rename the package.zip created by pnpm package
+          mv package.zip github-pr-ci-skip-v${{ steps.version.outputs.version }}.zip
 
-          # Copy built extension files from dist
-          cp -r dist/* release-package/
-          cp LICENSE release-package/
-          cp README.md release-package/
-
-          # Create zip file
-          cd release-package
-          zip -r ../github-pr-ci-skip-v${{ steps.version.outputs.version }}.zip -- *
-          cd ..
-
-          # Also create a source code archive
+          # Create a source code archive
           zip -r github-pr-ci-skip-source-v${{ steps.version.outputs.version }}.zip . \
             -x "*.git*" \
             -x "*node_modules*" \


### PR DESCRIPTION
## Summary
Use the existing `pnpm package` script defined in package.json instead of manually building and packaging in the release workflow.

## Changes
- Replace separate build step with `pnpm package` command
- Simplify release package creation by just renaming the generated package.zip
- Improves consistency with npm scripts and reduces duplication

## Test plan
- [ ] CI validates workflow syntax
- [ ] Next release will test the updated workflow