### PR TITLE
Simplify workflow event triggers

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,5 @@
 name: Lint GitHub Actions workflows
-on: [push, pull_request]
+on: push
 
 jobs:
   actionlint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [main, refactor]
-  pull_request:
-    branches: [main]
+on: push
 
 jobs:
   ci:


### PR DESCRIPTION
## Summary
Simplify GitHub Actions workflow triggers by removing unnecessary pull_request events and branch filters.

## Changes
- **actionlint.yml**: Remove `pull_request` event trigger
- **ci.yml**: 
  - Remove branch filters from `push` event
  - Remove `pull_request` event trigger
  
## Rationale
- Reduce duplicate CI runs (push event is sufficient)
- Simplify workflow configuration
- All pushes should be validated regardless of branch

## Test plan
- [x] Workflows run on push to this branch
- [ ] CI validates workflow syntax with actionlint
- [ ] All tests pass