### PR TITLE
Disable minification for Chrome extension

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   plugins: [crx({ manifest })],
   build: {
     sourcemap: true,
+    minify: false,
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
Disable minification in Vite build configuration since Chrome extensions don't require minified code.

## Changes
- Set `build.minify: false` in vite.config.ts
- Generated JavaScript is now readable without minification

## Rationale
- Chrome extensions don't have the same performance constraints as web pages
- Readable code makes debugging much easier
- Sourcemaps are still generated for additional debugging support
- File size increase (2.69KB → 5.41KB) is negligible for browser extensions

## Test plan
- [x] Verified build generates non-minified, readable JavaScript
- [x] Confirmed sourcemaps are still generated
- [ ] CI validates build process works correctly