### PR TITLE
Fix: Limit CI skip functionality to PR pages only

### DIFF
--- a/src/content-logic.ts
+++ b/src/content-logic.ts
@@ -225,7 +225,9 @@ export const setupObserver = () => {
 
 export const checkAndSetup = () => {
   // Only run on GitHub PR pages
-  const isPRPage = window.location.pathname.match(/^\/[^\/]+\/[^\/]+\/pull\/\d+/);
+  const isPRPage = window.location.pathname.match(
+    /^\/[^\/]+\/[^\/]+\/pull\/\d+/,
+  );
   if (!isPRPage) {
     cleanupObserver();
     return;

--- a/src/content-logic.ts
+++ b/src/content-logic.ts
@@ -224,6 +224,13 @@ export const setupObserver = () => {
 };
 
 export const checkAndSetup = () => {
+  // Only run on GitHub PR pages
+  const isPRPage = window.location.pathname.match(/^\/[^\/]+\/[^\/]+\/pull\/\d+/);
+  if (!isPRPage) {
+    cleanupObserver();
+    return;
+  }
+
   const prTitleField = findMergeTitleField();
 
   if (prTitleField) {

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -157,7 +157,15 @@ describe("Content Script", () => {
   });
 
   describe("checkAndSetup", () => {
-    it("should call appender when PR title field exists", () => {
+    beforeEach(() => {
+      // Mock window.location.pathname to be a PR page
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: { pathname: "/owner/repo/pull/123" },
+      });
+    });
+
+    it("should call appender when PR title field exists on PR page", () => {
       setupGitHubPRPage();
 
       checkAndSetup();
@@ -169,7 +177,7 @@ describe("Content Script", () => {
       );
     });
 
-    it("should setup observer when PR title field does not exist", () => {
+    it("should setup observer when PR title field does not exist on PR page", () => {
       // Start with empty DOM
       document.body.innerHTML = "";
 
@@ -181,6 +189,27 @@ describe("Content Script", () => {
         childList: true,
         subtree: true,
       });
+
+      observeSpy.mockRestore();
+    });
+
+    it("should not setup observer on non-PR pages", () => {
+      // Mock non-PR page
+      Object.defineProperty(window, "location", {
+        writable: true,
+        value: { pathname: "/owner/repo/issues/123" },
+      });
+
+      setupGitHubPRPage();
+      const observeSpy = vi.spyOn(MutationObserver.prototype, "observe");
+
+      checkAndSetup();
+
+      expect(observeSpy).not.toHaveBeenCalled();
+
+      // Verify appender was not called
+      const input = screen.getByLabelText("Commit message") as HTMLInputElement;
+      expect(input).toHaveValue("Merge pull request #123 from user/branch");
 
       observeSpy.mockRestore();
     });

--- a/test/content.test.ts
+++ b/test/content.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import {


### PR DESCRIPTION
## Summary
Fixes the issue where CI skip checkbox was appearing on non-PR pages by adding URL path validation.

## Problem
The extension was running on all GitHub pages, not just pull request pages, potentially showing the CI skip checkbox in inappropriate places.

## Solution
- Added URL path validation in `checkAndSetup()` function
- Extension now only activates on URLs matching `/owner/repo/pull/{number}`
- Observer is cleaned up when navigating away from PR pages

## Changes
- Updated `src/content-logic.ts` to check URL path before activation
- Added test coverage for PR page detection
- Added test for non-PR pages to ensure extension doesn't activate

## Test plan
- [x] Unit tests pass
- [x] Added new test case for non-PR pages
- [x] Existing tests updated to mock PR page URLs
- [ ] Manual testing on GitHub PR pages
- [ ] Manual testing on GitHub non-PR pages (issues, code, etc.)