### PR TITLE
Add debug logging for PR page detection

### DIFF
--- a/src/content-logic.ts
+++ b/src/content-logic.ts
@@ -225,19 +225,32 @@ export const setupObserver = () => {
 
 export const checkAndSetup = () => {
   // Only run on GitHub PR pages
-  const isPRPage = window.location.pathname.match(
-    /^\/[^\/]+\/[^\/]+\/pull\/\d+/,
-  );
+  const currentPath = window.location.pathname;
+  const isPRPage = currentPath.match(/^\/[^\/]+\/[^\/]+\/pull\/\d+/);
+
+  // Debug logging
+  console.log("[GitHub PR CI Skip] Current path:", currentPath);
+  console.log("[GitHub PR CI Skip] Is PR page:", !!isPRPage);
+
   if (!isPRPage) {
+    console.log("[GitHub PR CI Skip] Not a PR page, cleaning up observer");
     cleanupObserver();
     return;
   }
 
+  console.log("[GitHub PR CI Skip] PR page detected, setting up CI skip");
+
   const prTitleField = findMergeTitleField();
 
   if (prTitleField) {
+    console.log(
+      "[GitHub PR CI Skip] Merge dialog found, adding CI skip checkbox",
+    );
     appender();
   } else {
+    console.log(
+      "[GitHub PR CI Skip] Merge dialog not found, setting up observer",
+    );
     setupObserver();
   }
 };


### PR DESCRIPTION
## Summary
Add console.log statements to help debug PR page detection logic.

## Changes
- Log current pathname and PR page detection result
- Log whether merge dialog is found immediately or observer is set up
- All logs are prefixed with `[GitHub PR CI Skip]` for easy filtering

## Debug output examples
```javascript
// On PR page:
[GitHub PR CI Skip] Current path: /owner/repo/pull/123
[GitHub PR CI Skip] Is PR page: true
[GitHub PR CI Skip] PR page detected, setting up CI skip
[GitHub PR CI Skip] Merge dialog not found, setting up observer

// On non-PR page:
[GitHub PR CI Skip] Current path: /owner/repo/issues/456
[GitHub PR CI Skip] Is PR page: false
[GitHub PR CI Skip] Not a PR page, cleaning up observer
```

## Purpose
This helps troubleshoot:
- Why CI skip might appear on non-PR pages
- Whether the URL pattern matching is working correctly
- Whether the merge dialog detection is working

## Note
This is temporary debug code that can be removed once the issue is resolved.