### PR TITLE
Fix SPA navigation for PR page detection

### DIFF
--- a/src/content-logic.ts
+++ b/src/content-logic.ts
@@ -228,10 +228,6 @@ export const checkAndSetup = () => {
   const currentPath = window.location.pathname;
   const isPRPage = currentPath.match(/^\/[^\/]+\/[^\/]+\/pull\/\d+/);
 
-  console.log(
-    `[GitHub PR CI Skip] checkAndSetup called - Path: ${currentPath}, isPR: ${!!isPRPage}`,
-  );
-
   if (!isPRPage) {
     // Clean up any existing observers and elements when not on PR page
     cleanupObserver();
@@ -247,10 +243,8 @@ export const checkAndSetup = () => {
   const prTitleField = findMergeTitleField();
 
   if (prTitleField) {
-    console.log("[GitHub PR CI Skip] Merge dialog found immediately");
     appender();
   } else {
-    console.log("[GitHub PR CI Skip] Setting up observer for merge dialog");
     // Always set up observer on PR pages, even if it already exists
     setupObserver();
   }

--- a/src/content-logic.ts
+++ b/src/content-logic.ts
@@ -225,19 +225,33 @@ export const setupObserver = () => {
 
 export const checkAndSetup = () => {
   // Only run on GitHub PR pages
-  const isPRPage = window.location.pathname.match(
-    /^\/[^\/]+\/[^\/]+\/pull\/\d+/,
+  const currentPath = window.location.pathname;
+  const isPRPage = currentPath.match(/^\/[^\/]+\/[^\/]+\/pull\/\d+/);
+
+  console.log(
+    `[GitHub PR CI Skip] checkAndSetup called - Path: ${currentPath}, isPR: ${!!isPRPage}`,
   );
+
   if (!isPRPage) {
+    // Clean up any existing observers and elements when not on PR page
     cleanupObserver();
+    // Remove any existing CI skip checkbox
+    const existingCheckbox = document.getElementById("skip_ci_checkbox");
+    if (existingCheckbox) {
+      existingCheckbox.closest("button")?.remove();
+    }
     return;
   }
 
+  // We're on a PR page, ensure observer is active
   const prTitleField = findMergeTitleField();
 
   if (prTitleField) {
+    console.log("[GitHub PR CI Skip] Merge dialog found immediately");
     appender();
   } else {
+    console.log("[GitHub PR CI Skip] Setting up observer for merge dialog");
+    // Always set up observer on PR pages, even if it already exists
     setupObserver();
   }
 };

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,13 +1,30 @@
 import { checkAndSetup, cleanupObserver } from "./content-logic";
 
 const init = () => {
+  let lastPath = window.location.pathname;
+
   // Setup on initial load
   checkAndSetup();
 
-  // Listen for GitHub's pjax events (SPA navigation)
-  document.addEventListener("pjax:end", () => {
-    checkAndSetup();
-  });
+  // Function to handle navigation changes
+  const handleNavigation = () => {
+    const currentPath = window.location.pathname;
+    if (currentPath !== lastPath) {
+      console.log(
+        `[GitHub PR CI Skip] Navigation detected: ${lastPath} -> ${currentPath}`,
+      );
+      lastPath = currentPath;
+      checkAndSetup();
+    }
+  };
+
+  // Listen for GitHub's navigation events (both pjax and Turbo)
+  document.addEventListener("pjax:end", handleNavigation);
+  document.addEventListener("turbo:load", handleNavigation);
+  document.addEventListener("turbo:render", handleNavigation);
+
+  // Also listen for popstate for browser back/forward
+  window.addEventListener("popstate", handleNavigation);
 
   // Clean up observer when page unloads
   window.addEventListener("beforeunload", () => {

--- a/src/content.ts
+++ b/src/content.ts
@@ -10,9 +10,6 @@ const init = () => {
   const handleNavigation = () => {
     const currentPath = window.location.pathname;
     if (currentPath !== lastPath) {
-      console.log(
-        `[GitHub PR CI Skip] Navigation detected: ${lastPath} -> ${currentPath}`,
-      );
       lastPath = currentPath;
       checkAndSetup();
     }


### PR DESCRIPTION
## Summary
Fix the issue where CI skip functionality doesn't work when navigating to PR pages via SPA navigation.

## Problem
The extension had two issues:
1. When starting from a non-PR page and navigating to a PR page via SPA navigation, the observer wasn't being set up
2. Only worked correctly when directly loading a PR page URL

## Solution
- Track path changes and re-run setup on navigation
- Listen for multiple navigation events:
  - `pjax:end` (GitHub's older SPA framework)
  - `turbo:load` and `turbo:render` (GitHub's newer Turbo framework)
  - `popstate` (browser back/forward navigation)
- Clean up observer and remove CI skip checkbox when leaving PR pages
- Always re-setup observer when navigating to PR pages

## Technical Details
- Store `lastPath` to detect actual navigation changes
- Only call `checkAndSetup()` when the path actually changes
- Remove existing CI skip checkbox when navigating away from PR pages

## Test plan
- [x] Unit tests pass
- [x] Build completes successfully
- [ ] CI validation
- [ ] Manual testing:
  - Navigate from repo home to PR page
  - Navigate from issues to PR page  
  - Use browser back/forward buttons
  - Direct load PR page URL